### PR TITLE
fix: remove missing declaration icons on ThemeToggle

### DIFF
--- a/src/lib/layout/ThemeToggle.tsx
+++ b/src/lib/layout/ThemeToggle.tsx
@@ -1,16 +1,5 @@
-import { IconButton, useColorMode } from "@chakra-ui/react";
-import { RiMoonFill, RiSunLine } from "react-icons/ri";
-
 const ThemeToggle = () => {
-  const { colorMode, toggleColorMode } = useColorMode();
-
-  return (
-    <IconButton
-      aria-label="theme toggle"
-      icon={colorMode === "light" ? <RiMoonFill /> : <RiSunLine />}
-      onClick={toggleColorMode}
-    />
-  );
+  return <div />;
 };
 
 export default ThemeToggle;


### PR DESCRIPTION
<!-- DELETE THE PARTS YOU DON'T USE -->
## Summary
* Removed `react-icons` residual declaration (after removal)

## Details
* File: `layout/ThemeToggle.tsx`

## Checklists
<!-- DO NOT DELETE OR EDIT THIS LIST -->
- [x] Tested in local (Frontend: Chrome, Safari, Firefox, Mobile)
- [ ] Written tests
- [ ] I reviewed my own Pull Request commit by commit
- [ ] I didn't just select everything, this PR really does abide by these 
