### PR TITLE
Fix navigation issue (white background regardless which theme is applied)

### DIFF
--- a/src/lib/compositions/NavBar.tsx
+++ b/src/lib/compositions/NavBar.tsx
@@ -5,6 +5,7 @@ import {
   Link,
   IconButton,
   useDisclosure,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import CTA from "@components/cta/CTA";
 import Logo from "@components/logo/Logo";
@@ -20,6 +21,7 @@ const Links = ["Dashboard", "Projects", "Team"];
 const NavBar: FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { setLocked } = useLockedBody();
+  const mobileMenuBackground = useColorModeValue("white", "#272727");
 
   useEffect(() => {
     setLocked(isOpen);
@@ -81,7 +83,7 @@ const NavBar: FC = () => {
           w="full"
           height="calc(100vh - 90px)"
           transform="translateY(100%)"
-          backgroundColor="white"
+          backgroundColor={mobileMenuBackground}
         >
           <Flex
             as="nav"
@@ -107,7 +109,7 @@ const NavBar: FC = () => {
                   height="30px"
                   width="30px"
                   fill="#00C4A2"
-                  stroke="white"
+                  stroke={mobileMenuBackground}
                 />
               </Link>
             ))}


### PR DESCRIPTION
<!-- DELETE THE PARTS YOU DON'T USE -->
## Summary
Fixed `white` background was applied to the mobile sub-menu. Used `useColorModeValue` to fix it.

## Testing
* Mobile sub-menu background should sync with current theme variant
* Build should pass

## Checklists
<!-- DO NOT DELETE OR EDIT THIS LIST -->
- [x] Tested locally (Frontend: Chrome, Safari, Firefox, Mobile)
- [ ] Written tests
- [x] I reviewed my own Pull Request commit by commit
- [x] I didn't just select everything, this PR really does abide by these ^

## Screenshots
<!-- ANY UI-RELATED CHANGE MUST HAVE SCREENSHOTS FOR ALL OF THESE -->
![image](https://user-images.githubusercontent.com/29380502/211262112-32b52f50-fb54-4e5b-b15c-b63f597d8def.png)
