### PR TITLE
Fix mobile navigation issues

### DIFF
--- a/src/lib/compositions/NavBar.tsx
+++ b/src/lib/compositions/NavBar.tsx
@@ -12,22 +12,34 @@ import Logo from "@components/logo/Logo";
 import { MAX_WIDTH } from "@helpers/ui-values";
 import { useLockedBody } from "@hooks";
 import NextLink from "next/link";
+import { useRouter } from "next/router";
 import type { FC } from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { Menu as MenuIcon, X, ArrowRightCircle } from "react-feather";
 
 const Links = ["Dashboard", "Projects", "Team"];
 
 const NavBar: FC = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen, onOpen, onClose, onToggle } = useDisclosure();
   const { setLocked } = useLockedBody();
+
   const mobileMenuBackground = useColorModeValue("white", "#272727");
+  const router = useRouter();
 
   useEffect(() => {
     setLocked(isOpen);
 
     return () => setLocked(false);
   }, [isOpen, setLocked]);
+
+  const hide = useCallback(() => {
+    onToggle();
+  }, [onToggle]);
+
+  useEffect(() => {
+    router.events.on("beforeHistoryChange", hide);
+    return () => router.events.off("beforeHistoryChange", hide);
+  }, [hide, router.events]);
 
   return (
     <Box as="header" pos="relative" zIndex="1">


### PR DESCRIPTION
<!-- DELETE THE PARTS YOU DON'T USE -->
## Summary
There were two active bugs 🐛 related to navigation: 
* Static background color of mobile sub-menu
* Mobile sub-menu wasn't closing when clicking a link (persistent layout)

## Details
* Both are fixed
* `useColorModeValue` -> color fix
* `useRouter` and `beforeHistoryChange` event -> layout fix

## Testing
* Mobile sub-menu Color should be the same as the body color
* Mobile sub-menu should close when clicking a link

## Checklists
<!-- DO NOT DELETE OR EDIT THIS LIST -->
- [x] Tested locally (Frontend: Chrome, Safari, Firefox, Mobile)
- [ ] Written tests
- [x] I reviewed my own Pull Request commit by commit
- [x] I didn't just select everything, this PR really does abide by these ^

