### PR TITLE
Decreased size and adjusted to smaller screens (avoid logo collision)

### DIFF
--- a/src/lib/compositions/FixedBlobs.tsx
+++ b/src/lib/compositions/FixedBlobs.tsx
@@ -17,7 +17,9 @@ const FixedBlobs: FC<Props> = ({
 
   return (
     <Box
-      display={hideBlobsOnMobile ? ["none", null, null, "block"] : "block"}
+      display={
+        hideBlobsOnMobile ? ["none", null, null, null, null, "block"] : "block"
+      }
       pos="fixed"
       h={height || "100vh"}
       w="100vw"
@@ -27,20 +29,20 @@ const FixedBlobs: FC<Props> = ({
     >
       <Box
         pos="fixed"
-        bottom={["50%", "45%", "35%", null, null, "30%"]}
-        left={["-40%", "-30%", "-20%", "-20%", null, "-10%"]}
-        w={["300px", "350px", "400px", null, "500px", "600px"]}
-        h={["300px", "350px", "400px", null, "500px", "600px"]}
+        top={["40%", "35%", "25%", null, null, "20%"]}
+        left={["-40%", "-30%", "-20%", "-20%", null, "-15%"]}
+        w={["300px", "350px", "400px", null, "500px"]}
+        h={["300px", "350px", "400px", null, "500px"]}
       >
         <Blob type={2} />
       </Box>
 
       <Box
         pos="fixed"
-        top={["50%", null, "50%"]}
-        right={["-50%", "-35%", "-20%", "-10%"]}
-        w={["300px", "400px", "400px", null, "500px", "600px"]}
-        h={["300px", "400px", "400px", null, "500px", "600px"]}
+        bottom="-20%"
+        right={["-50%", "-35%", "-20%", "-15%"]}
+        w={["300px", "400px", "400px", null, "500px"]}
+        h={["300px", "400px", "400px", null, "500px"]}
       >
         <Blob type={0} isInverted />
       </Box>


### PR DESCRIPTION
<!-- DELETE THE PARTS YOU DON'T USE -->
## Summary
`FixedBlobs` were overlapping some elements such as Logo, which made it difficult for the user to read the content. 
This PR fixes those issues

## Details
* Size decreased
* Fixed position re-adjusted

## Testing
* Blobs shouldn't overlap any important element on any screen
* Build should pass

## Checklists
<!-- DO NOT DELETE OR EDIT THIS LIST -->
- [x] Tested locally (Frontend: Chrome, Safari, Firefox, Mobile)
- [ ] Written tests
- [x] I reviewed my own Pull Request commit by commit
- [x] I didn't just select everything, this PR really does abide by these ^

## Screenshots
<!-- ANY UI-RELATED CHANGE MUST HAVE SCREENSHOTS FOR ALL OF THESE -->
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/29380502/211730028-2da9b51f-3d55-437c-ad81-e39a549de70b.png">
