### PR TITLE
Fix scroll on mobile

### DIFF
--- a/src/lib/views/home/modules/Slider/Slider.tsx
+++ b/src/lib/views/home/modules/Slider/Slider.tsx
@@ -23,7 +23,15 @@ const SliderTrack: FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <Flex gap="20px" maxW="100vw" overflow="auto" px="20px">
+    <Flex
+      gap="20px"
+      maxW="100vw"
+      overflowX="auto"
+      sx={{
+        "-webkit-overflow-scrolling": "touch",
+      }}
+      px="20px"
+    >
       {SOURCE_LIST.map(({ id, videoUrl, posterUrl }) => {
         return (
           <SliderCard


### PR DESCRIPTION
<!-- DELETE THE PARTS YOU DON'T USE -->
## Summary
Fix the mobile issue on iPhone 11 (at least). `overflow-x` and webkit fallback

